### PR TITLE
Fix Node timeout type

### DIFF
--- a/src/Menu.ts
+++ b/src/Menu.ts
@@ -19,7 +19,7 @@ export default class Menu {
       this.game.music.setMusicVolume(parseFloat(this.musicVolumeSlider.value));
     });
 
-    let soundEffectTimeout: NodeJS.Timeout;
+    let soundEffectTimeout: ReturnType<typeof setTimeout>;
     this.fxVolumeSlider.addEventListener('input', () => {
       this.game.music.setFxVolume(parseFloat(this.fxVolumeSlider.value));
       if (soundEffectTimeout) clearTimeout(soundEffectTimeout);


### PR DESCRIPTION
## Summary
- fix timer type in `Menu.ts`

## Testing
- `npx tsc --noEmit` *(fails: cannot find type definition files)*
- `npm run lint` *(fails: ESLint couldn't find a config)*


------
https://chatgpt.com/codex/tasks/task_e_684741a1c22c83278e4e67e22880f8d9